### PR TITLE
DAT-4593: Tiny typo changes

### DIFF
--- a/src/main/resources/openshift/mpp-namespace-template.yaml
+++ b/src/main/resources/openshift/mpp-namespace-template.yaml
@@ -3,7 +3,7 @@ apiVersion: "v1"
 metadata:
   name: "namespace-template"
 labels:
-  template: "namnespace-template"
+  template: "namespace-template"
 parameters:
   - name: "APP_CODE"
     description: "App code of the parent project"

--- a/src/main/resources/openshift/mpp-prepare-namespace.yaml
+++ b/src/main/resources/openshift/mpp-prepare-namespace.yaml
@@ -3,7 +3,7 @@ apiVersion: "v1"
 metadata:
   name: "namespace-template"
 labels:
-  template: "namnespace-template"
+  template: "namespace-template"
 parameters:
   - name: "APP_CODE"
     description: "App code of the parent project"
@@ -12,7 +12,7 @@ parameters:
     description: "Name of the parent project"
     required: true
   - name: "NS_NAME"
-    description: "based on web property  and the tenant the automation will create the namespace"
+    description: "based on web property and the tenant the automation will create the namespace"
     required: true
   - name: "DEVOPS_NAMING_CONVENTION"
     description: "deployment naming convention for related resources"


### PR DESCRIPTION
While reviewing the OpenShift templates, I encountered a couple of instances where 'namespace' was spelled 'namnespace' which I believe is a typo. I thought I'd offer a tiny, friendly pull request resolving these typos.