### PR TITLE
Fixed symlink recreation issue in SPAship

### DIFF
--- a/src/main/java/io/spaship/operator/service/k8s/CommandExecutionService.java
+++ b/src/main/java/io/spaship/operator/service/k8s/CommandExecutionService.java
@@ -83,7 +83,7 @@ public class CommandExecutionService {
         source = (BASE_HTTP_DIR.concat("/").concat(source));
         target = (BASE_HTTP_DIR.concat("/").concat(target));
         LOG.debug("creating a symlink of source {} to {}",source,target);
-        String command = "rm -f " + target + " && ln -s " + source + " " + target;
+        String command = "rm -f " + target + "; ln -s " + source + " " + target;
         LOG.debug("command to be executed {}",command);
         return new String[]{"sh", "-c", command};
     }


### PR DESCRIPTION
### Description:
This PR addresses the issue of recreating symlinks that were manually created and then uploaded to SPAship. The `symbolicLinkCommand` method in the `CommandExecutionService` class has been updated to force the creation of the new symlink, even if a file with the same name already exists.
### How to Test:
1. Manually create symlinks on the local environment.
2. Upload symlinks to SPAship using deployment.
3. Attempt to recreate symlinks from SPAship.
4. Verify that the symlinks are recreated without any errors.