### PR TITLE
chore: limits increased for the operator

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # file uploading config
-quarkus.http.limits.max-body-size=204800K
+quarkus.http.limits.max-body-size=512000K
 quarkus.http.body.uploads-directory=/tmp/operator
 quarkus.http.body.handle-file-uploads=true
 quarkus.http.body.delete-uploaded-files-on-end=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # file uploading config
-quarkus.http.limits.max-body-size=102400K
+quarkus.http.limits.max-body-size=204800K
 quarkus.http.body.uploads-directory=/tmp/operator
 quarkus.http.body.handle-file-uploads=true
 quarkus.http.body.delete-uploaded-files-on-end=false

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 # file uploading config
-quarkus.http.limits.max-body-size=102400K
+quarkus.http.limits.max-body-size=512000K
 quarkus.http.body.uploads-directory=/tmp/operator
 quarkus.http.body.handle-file-uploads=true
 quarkus.http.body.delete-uploaded-files-on-end=false


### PR DESCRIPTION
Subject: chore: limits increased for the operator
Assignees: @soumyadip007

## Closes / Fixes

1. For a few of the scenarios we're getting `413 Errors` from the operator `Entity too Large`, this thing will fix that issue.
2. Increase the HTTP Max Body Size limit to 500 MB from 100 MB

## Does this PR introduce a breaking change

NO

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->

## Screenshot(s)

<!-- If applicable, add screenshots to help explain your problem. -->

<details>
<summary>View Screenshots</summary>

<!-- Add your screenshot(s) below this line -->

</details>

### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Does the change have appropriate unit tests?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?